### PR TITLE
Fix error in gem releasing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "coveralls"
+gem "ostruct"
 gem "prismdb"
 gem "rake", "~> 12.0"
 gem "rspec", "~> 3.0"


### PR DESCRIPTION
https://github.com/sue445/faker-pretty_series/actions/runs/32622471647/job/97152639088

```
Run bundle exec rake release
  /home/runner/work/faker-pretty_series/faker-pretty_series/vendor/bundle/ruby/4.0.0/gems/rake-12.3.3/lib/rake.rb:33: warning: ostruct used to be loaded from the standard library, but is not part of the default gems since Ruby 4.0.0.
  You can add ostruct to your Gemfile or gemspec to fix this error.
  bundler: failed to load command: rake (/home/runner/work/faker-pretty_series/faker-pretty_series/vendor/bundle/ruby/4.0.0/bin/rake)
  /opt/hostedtoolcache/Ruby/4.0.6/x64/lib/ruby/4.0.0/bundled_gems.rb:60:in 'Kernel.require': cannot load such file -- ostruct (LoadError)
  Did you mean?  tsort
  	from /opt/hostedtoolcache/Ruby/4.0.6/x64/lib/ruby/4.0.0/bundled_gems.rb:60:in 'block (2 levels) in Kernel#replace_require'
  	from /home/runner/work/faker-pretty_series/faker-pretty_series/vendor/bundle/ruby/4.0.0/gems/rake-12.3.3/lib/rake.rb:33:in '<top (required)>'
  	from /opt/hostedtoolcache/Ruby/4.0.6/x64/lib/ruby/4.0.0/bundled_gems.rb:60:in 'Kernel.require'
  	from /opt/hostedtoolcache/Ruby/4.0.6/x64/lib/ruby/4.0.0/bundled_gems.rb:60:in 'block (2 levels) in Kernel#replace_require'
  	from /home/runner/work/faker-pretty_series/faker-pretty_series/vendor/bundle/ruby/4.0.0/gems/rake-12.3.3/exe/rake:25:in '<top (required)>'
  	from /opt/hostedtoolcache/Ruby/4.0.6/x64/lib/ruby/4.0.0/rubygems.rb:305:in 'Kernel#load'
  	from /opt/hostedtoolcache/Ruby/4.0.6/x64/lib/ruby/4.0.0/rubygems.rb:305:in 'Gem.activate_and_load_bin_path'
  	from /home/runner/work/faker-pretty_series/faker-pretty_series/vendor/bundle/ruby/4.0.0/bin/rake:25:in '<top (required)>'
  	from /opt/hostedtoolcache/Ruby/4.0.6/x64/lib/ruby/4.0.0/bundler/cli/exec.rb:61:in 'Kernel.load'
  	from /opt/hostedtoolcache/Ruby/4.0.6/x64/lib/ruby/4.0.0/bundler/cli/exec.rb:61:in 'Bundler::CLI::Exec#kernel_load'
  	from /opt/hostedtoolcache/Ruby/4.0.6/x64/lib/ruby/4.0.0/bundler/cli/exec.rb:24:in 'Bundler::CLI::Exec#run'
  	from /opt/hostedtoolcache/Ruby/4.0.6/x64/lib/ruby/4.0.0/bundler/cli.rb:508:in 'Bundler::CLI#exec'
  	from /opt/hostedtoolcache/Ruby/4.0.6/x64/lib/ruby/4.0.0/bundler/vendor/thor/lib/thor/command.rb:28:in 'Bundler::Thor::Command#run'
  	from /opt/hostedtoolcache/Ruby/4.0.6/x64/lib/ruby/4.0.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in 'Bundler::Thor::Invocation#invoke_command'
  	from /opt/hostedtoolcache/Ruby/4.0.6/x64/lib/ruby/4.0.0/bundler/vendor/thor/lib/thor.rb:538:in 'Bundler::Thor.dispatch'
  	from /opt/hostedtoolcache/Ruby/4.0.6/x64/lib/ruby/4.0.0/bundler/cli.rb:35:in 'Bundler::CLI.dispatch'
  	from /opt/hostedtoolcache/Ruby/4.0.6/x64/lib/ruby/4.0.0/bundler/vendor/thor/lib/thor/base.rb:584:in 'Bundler::Thor::Base::ClassMethods#start'
  	from /opt/hostedtoolcache/Ruby/4.0.6/x64/lib/ruby/4.0.0/bundler/cli.rb:29:in 'Bundler::CLI.start'
  	from /opt/hostedtoolcache/Ruby/4.0.6/x64/lib/ruby/gems/4.0.0/gems/bundler-4.0.16/exe/bundle:28:in 'block in <top (required)>'
  	from /opt/hostedtoolcache/Ruby/4.0.6/x64/lib/ruby/4.0.0/bundler/friendly_errors.rb:118:in 'Bundler.with_friendly_errors'
  	from /opt/hostedtoolcache/Ruby/4.0.6/x64/lib/ruby/gems/4.0.0/gems/bundler-4.0.16/exe/bundle:20:in '<top (required)>'
  	from /opt/hostedtoolcache/Ruby/4.0.6/x64/lib/ruby/4.0.0/rubygems.rb:305:in 'Kernel#load'
  	from /opt/hostedtoolcache/Ruby/4.0.6/x64/lib/ruby/4.0.0/rubygems.rb:305:in 'Gem.activate_and_load_bin_path'
  	from /opt/hostedtoolcache/Ruby/4.0.6/x64/bin/bundle:25:in '<main>'

```